### PR TITLE
Fix .pc file by adding required packages instead of having broken Cflags

### DIFF
--- a/src/cpp_bagel_wrapper.pc.in
+++ b/src/cpp_bagel_wrapper.pc.in
@@ -6,7 +6,7 @@ includedir=${prefix}/include
 Name: @PROJECT_NAME@
 Description: @PROJECT_DESCRIPTION@
 Version: @PROJECT_VERSION@
-Requires: @PKGCONFIG_REQUIRES@
-Libs: -L${libdir} -l@PROJECT_NAME@ @PKGCONFIG_LIBS@
-Cflags: -I${includedir} @PKGCONFIG_CFLAGS@
+Requires: mars_utils c_bagel configmaps
+Libs: -L${libdir} -l@PROJECT_NAME@
+Cflags: -I${includedir}
 


### PR DESCRIPTION
The Cflags directly used a cmake list which is clearly wrong, and did not mention its library dependencies because PKGCONFIG_REQUIRES and PKGCONFIG_LIBS is only set by the Rock.cmake macros.